### PR TITLE
Don't use browser alias for component-type dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  */
 
 try {
-  var type = require('type');
+  var type = require('component-type');
 } catch (err) {
   var type = require('component-type');
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "component-type": "1.0.0",
     "to-function": "2.0.6"
   },
-  "browser": {
-    "type": "component-type"
-  },
   "devDependencies": {
     "mocha": "*",
     "should": "*"


### PR DESCRIPTION
This way, `component-each` won't break node code/tests when imported.

Please point-release after merging!
